### PR TITLE
storj-protobuf: update protoc-gen-drpc to v0.0.16

### DIFF
--- a/storj-protobuf/main.go
+++ b/storj-protobuf/main.go
@@ -54,7 +54,7 @@ func run(command, root string) error {
 		}
 		return install(
 			"github.com/ckaznocha/protoc-gen-lint@68a05858965b31eb872cbeb8d027507a94011acc",
-			"storj.io/drpc/cmd/protoc-gen-drpc@v0.0.6",
+			"storj.io/drpc/cmd/protoc-gen-drpc@v0.0.16",
 			"github.com/nilslice/protolock/cmd/protolock@v0.12.0",
 		)
 


### PR DESCRIPTION
What: update `protoc-gen-drpc` to v0.0.16 for `storj-protobuf`

Why: `go run ./storj-protobuf/main.go install` installing `protoc-gen-drpc` v0.0.6 which compiles outdated protobuf. Updating `protoc-gen-drpc` to v0.0.16 solves this issue.