### PR TITLE
images: installs playwright, deps, and browsers

### DIFF
--- a/images/ci.sh
+++ b/images/ci.sh
@@ -21,4 +21,5 @@ apt -y install /tmp/duplicati.deb
 
 # Requirements for UI tests
 npx playwright install-deps
+npx playwright install
 npm install -D @playwright/test

--- a/images/ci.sh
+++ b/images/ci.sh
@@ -21,3 +21,4 @@ apt -y install /tmp/duplicati.deb
 
 # Requirements for UI tests
 npx playwright install-deps
+npm install -D @playwright/test

--- a/images/ci.sh
+++ b/images/ci.sh
@@ -20,4 +20,4 @@ curl -sfL https://github.com/duplicati/duplicati/releases/download/v2.0.5.114-2.
 apt -y install /tmp/duplicati.deb
 
 # Requirements for UI tests
-DEBIAN_FRONTEND="noninteractive" apt install -y chromium xorg xvfb gtk2-engines-pixbuf dbus-x11 xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic xfonts-scalable imagemagick x11-apps
+npx playwright install-deps


### PR DESCRIPTION
This change removes the requirements from the old ui tests and installs playwright, its dependencies, as well as chromium, edge, and firefox browsers to be tested against in headless mode.