### PR TITLE
storj-release: use explicit ld flags

### DIFF
--- a/storj-release/release.go
+++ b/storj-release/release.go
@@ -88,6 +88,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if env.GoVersion == "" {
+		_, _ = fmt.Fprintf(os.Stderr, "Please specify go version with -go-version (tag of storjlabs/golang Docker image)")
+		os.Exit(1)
+	}
+
 	env.LDFLAGS = strings.TrimSpace(os.Getenv("LDFLAGS"))
 
 	gopath, err := getGoEnv("GOPATH")
@@ -323,7 +328,6 @@ func (env *Env) BuildComponentBinary(tagdir, component string, osarch OsArch) er
 		// setup correct os/arch
 		"-e", "GOOS=" + osarch.Os, "-e", "GOARCH=" + osarch.Arch,
 		"-e", "GOARM=6", "-e", "CGO_ENABLED=" + env.CGOENABLED,
-		"-e", "LDFLAGS=" + ldFlags,
 		// use goproxy
 		"-e", "GOPROXY",
 		// use our golang image
@@ -331,7 +335,7 @@ func (env *Env) BuildComponentBinary(tagdir, component string, osarch OsArch) er
 	}
 
 	buildArgs := []string{
-		"go", "build", "-o", filepath.ToSlash(binaryPath),
+		"go", "build", "-ldflags", ldFlags, "-o", filepath.ToSlash(binaryPath),
 	}
 	if buildTags != "" {
 		buildArgs = append(buildArgs, "-tags", buildTags)


### PR DESCRIPTION
I would like to have debug information in edge (and storjscan) binaries.

I don't see too much benefits in removing these flags from our binaries which are distributed and used by us, as size of the files are not a very big concern.

On the other hand I would like to have the debug information to analyze core dumps.

This is not possible today, as "-s -w" flags are forced by our docker image here: https://github.com/storj/docker-golang/blob/2e1eb2d53a37590c1d55791bc1ef54922cd37bb4/cc#L145

Unless we use -ldflags instead of $LDFLAGS, where the given ldflags are respected.

Change-Id: Iee2cc41388977ad9ed23f8624e79fa3502c71fff
